### PR TITLE
Add `type` to proof request typing

### DIFF
--- a/typings/application/datatypes.d.ts
+++ b/typings/application/datatypes.d.ts
@@ -197,6 +197,7 @@ export interface ProofRequest {
   prover: string;
   createdAt: string;
   nonce: Nonce;
+  type: string;
   subProofRequests: SubProofRequest[];
 }
 


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Adds type to proof request typing to align typings with datatypes.